### PR TITLE
FIX number of parameters at ArgumentCountError exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpseclib/phpseclib": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
+        "phpunit/phpunit": "^10.5|^11.1",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
-    backupGlobals="false"
-    colors="true"
-    bootstrap="vendor/autoload.php"
-    >
-    <testsuites>
-        <testsuite name="phpseclib Unit Test Suite">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>lib/</directory>
-        </whitelist>
-    </filter>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd"
+  backupGlobals="false"
+  colors="true"
+  bootstrap="vendor/autoload.php"
+  cacheDirectory=".phpunit.cache"
+  >
+  <testsuites>
+    <testsuite name="phpseclib Unit Test Suite">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>lib/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/BCMath.php
+++ b/src/BCMath.php
@@ -363,12 +363,13 @@ abstract class BCMath
             'sqrt' => 2,
             'sub' => 3
         ];
-        if (count($arguments) < $params[$name] - 1) {
+        $cnt = count($arguments);
+        if ($cnt < $params[$name] - 1) {
             $min = $params[$name] - 1;
-            throw new \ArgumentCountError("bc$name() expects at least $min parameters, " . func_num_args() . " given");
+            throw new \ArgumentCountError("bc$name() expects at least $min parameters, " . $cnt . " given");
         }
-        if (count($arguments) > $params[$name]) {
-            $str = "bc$name() expects at most {$params[$name]} parameters, " . func_num_args() . " given";
+        if ($cnt > $params[$name]) {
+            $str = "bc$name() expects at most {$params[$name]} parameters, " . $cnt . " given";
             throw new \ArgumentCountError($str);
         }
         $numbers = array_slice($arguments, 0, $params[$name] - 1);

--- a/tests/BCMathTest.php
+++ b/tests/BCMathTest.php
@@ -1,18 +1,26 @@
-<?php
+<?php //declare(strict_types=1);
 
 use bcmath_compat\BCMath;
 
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+// use PHPUnit\Framework\Attributes\TestWith;
+
 /**
- * @requires extension bcmath
+ * requires extension bcmath
  */
-class BCMathTest extends PHPUnit\Framework\TestCase
+#[RequiresPhpExtension('bcmath')]
+class BCMathTest extends TestCase
 {
+    static $emsg = '';
     /**
      * Produces all combinations of test values.
      *
      * @return array
      */
-    public function generateTwoParams()
+    public static function generateTwoParams()
     {
         $r = [
             ['9', '9'],
@@ -45,9 +53,7 @@ class BCMathTest extends PHPUnit\Framework\TestCase
         return $r;
     }
 
-    /**
-     * @dataProvider generateTwoParams
-     */
+    #[DataProvider('generateTwoParams')]
     public function testAdd(...$params)
     {
         $a = bcadd(...$params);
@@ -60,9 +66,7 @@ class BCMathTest extends PHPUnit\Framework\TestCase
         $this->assertSame($a, $b);
     }
 
-    /**
-     * @dataProvider generateTwoParams
-     */
+    #[DataProvider('generateTwoParams')]
     public function testSub(...$params)
     {
         $a = bcsub(...$params);
@@ -76,9 +80,11 @@ class BCMathTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider generateTwoParams
-     * @requires PHP 7.3
+     * requires PHP 7.3
      */
+
+    #[RequiresPhp('>7.3')]
+    #[DataProvider('generateTwoParams')]
     public function testMul(...$params)
     {
         $a = bcmul(...$params);
@@ -91,9 +97,7 @@ class BCMathTest extends PHPUnit\Framework\TestCase
         $this->assertSame($a, $b);
     }
 
-    /**
-     * @dataProvider generateTwoParams
-     */
+    #[DataProvider('generateTwoParams')]
     public function testDiv(...$params)
     {
         if ($params[1] === '0' || $params[1] === '-0') {
@@ -110,9 +114,12 @@ class BCMathTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider generateTwoParams
-     * @requires PHP 7.2
+     * dataProvider generateTwoParams
+     * requires PHP 7.2
      */
+
+    #[DataProvider('generateTwoParams')]
+    #[RequiresPhp('>7.2')]
     public function testMod(...$params)
     {
         if ($params[1] === '0' || $params[1] === '-0') {
@@ -133,7 +140,7 @@ class BCMathTest extends PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function generatePowParams()
+    public static function generatePowParams()
     {
         return [
             ['9', '9'],
@@ -154,8 +161,10 @@ class BCMathTest extends PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider generatePowParams
-     * @requires PHP 7.3
+     * requires PHP 7.3
      */
+    #[DataProvider('generatePowParams')]
+    #[RequiresPhp('>7.3')]
     public function testPow(...$params)
     {
         $a = bcpow(...$params);
@@ -168,7 +177,7 @@ class BCMathTest extends PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function generatePowModParams()
+    public static function generatePowModParams()
     {
         return [
             ['9', '9', '17'],
@@ -188,10 +197,13 @@ class BCMathTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider generatePowModParams
-     * @requires PHP 7.3
+     * dataProvider generatePowModParams
+     * requires PHP 7.3
      */
-    public function testPowMod(...$params)
+     #[DataProvider('generatePowModParams')]
+     #[RequiresPhp('>7.3')]
+
+     public function testPowMod(...$params)
     {
         $a = bcpowmod(...$params);
         $b = BCMath::powmod(...$params);
@@ -215,9 +227,19 @@ class BCMathTest extends PHPUnit\Framework\TestCase
 
     public function testBoolScale()
     {
-        $a = bcadd('5', '2', false);
-        $b = BCMath::add('5', '2', false);
-        $this->assertSame($a, $b);
+        if(false) {
+            $exception_thrown = false;
+            try {
+                $a = bcadd('5', '2', false);
+            } catch (TypeError $e) {
+                $exception_thrown = true;
+            }
+            $this->assertSame(true, $exception_thrown);
+        } else {
+            $a = bcadd('5','2', false);
+            $b = BCMath::add('5', '2', false);
+            $this->assertSame($a, $b);
+        }
     }
 
     public function testIntParam()
@@ -244,6 +266,77 @@ class BCMathTest extends PHPUnit\Framework\TestCase
         }
         if (!empty($code)) {
             $this->expectExceptionCode($code);
+        }
+    }
+
+    public static function generateScaleCallstaticParams()
+    {
+        return [
+            [4],
+            [4,2],
+            [4,2,3],
+            [4,2,3,5],
+        ];
+    }
+
+    #[DataProvider('generateScaleCallstaticParams')]
+    public function test_argumentsScaleCallstatic(...$params)
+    {
+        //scale with 1, 2, 3 parameters
+        if (func_num_args() == 1) {
+            bcscale(...$params);
+            BCMath::scale(...$params);
+            $scale = bcscale();
+            $orig = $params[0];
+            $this->assertSame($orig,$scale);
+            $scale = BCMath::scale();
+            $this->assertSame($orig,$scale);
+        } else {
+            $exception_thrown = false;
+            try{
+                BCMath::scale(...$params);
+            } catch (ArgumentCountError $e) {
+                $exception_thrown = true;
+            }
+            $this->assertSame(true, $exception_thrown);
+            if (true) {
+                // start the unit test with: (showing the wrong given values)
+                // phpunit --testdox-test testdox.txt --display-skipped
+                $this->markTestSkipped('ArgumentCountError in ' . $e->getFile() . ':' . $e->getLine() . ' : ' . $e->getMessage());
+            }
+        }
+    }
+    public static function generatePowModCallstaticParams()
+    {
+        return [
+            ['9'],
+            ['9', '17'],
+            ['9', '17', '-111'],
+            ['9', '17', '-111', 5],
+            ['9', '17', '-111', 5, 8],
+        ];
+    }
+    #[DataProvider('generatePowModCallstaticParams')]
+    public function test_argumentsPowModCallstatic(...$params)
+    {
+        //scale with 1, 2, 3 parameters
+        if (func_num_args() > 2 && func_num_args() < 5) {
+            $a = bcpowmod(...$params);
+            $b = BCMath::powmod(...$params);
+            $this->assertSame($a,$b);
+        } else {
+            $exception_thrown = false;
+            try{
+                BCMath::powmod(...$params);
+            } catch (ArgumentCountError $e) {
+                $exception_thrown = true;
+            }
+            $this->assertSame(true, $exception_thrown);
+            if (true) {
+                // start the unit test with: (showing the wrong given values)
+                // phpunit --testdox-test testdox.txt --display-skipped
+                $this->markTestSkipped('ArgumentCountError in ' . $e->getFile() . ':' . $e->getLine() . ' : ' . $e->getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
tl;dr
The exception ArgumentCountError gives wrong given parameter length.

The `func_num_args()` used - only returns the number of parameters of the called function and is always 2 in this case.
You are probably wondering why I came up with this? My editor shows me an error that the parameters for the `__callStatic()` magic function should always be the amount of 2.

I also adapted the test file with phpunit version 11.1.3, expanded it and checked the output with `phpunit --testdox-test testdox.txt --display-skipped`:

```
tom@silver ~/github/bcmath_compat (git)-[master] % phpunit --testdox-text testdox.txt --display-skipped
PHPUnit 11.1.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.7
Configuration: /home/tom/github/bcmath_compat/phpunit.xml.dist

...............................................................  63 / 152 ( 41%)
............................................................... 126 / 152 ( 82%)
..................SSSSS..S                                      152 / 152 (100%)

Time: 00:00.154, Memory: 26.86 MB

There were 6 skipped tests:

1) BCMathTest::test_argumentsScaleCallstatic with data set #1 (4, 2)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:372 : bcscale() expects at most 1 parameters, 2 given

2) BCMathTest::test_argumentsScaleCallstatic with data set #2 (4, 2, 3)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:372 : bcscale() expects at most 1 parameters, 2 given

3) BCMathTest::test_argumentsScaleCallstatic with data set #3 (4, 2, 3, 5)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:372 : bcscale() expects at most 1 parameters, 2 given

4) BCMathTest::test_argumentsPowModCallstatic with data set #0 ('9')
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:368 : bcpowmod() expects at least 3 parameters, 2 given

5) BCMathTest::test_argumentsPowModCallstatic with data set #1 ('9', '17')
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:368 : bcpowmod() expects at least 3 parameters, 2 given

6) BCMathTest::test_argumentsPowModCallstatic with data set #4 ('9', '17', '-111', 5, 8)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:372 : bcpowmod() expects at most 4 parameters, 2 given

OK, but some tests were skipped!
Tests: 152, Assertions: 155, Skipped: 6.
```
Now with the patch, which is also attached, we get:
[bcmath_patch.txt](https://github.com/user-attachments/files/15523565/bcmath_patch.txt)

```
tom@silver ~/github/bcmath_compat (git)-[master] % phpunit --testdox-text testdox.txt --display-skipped
PHPUnit 11.1.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.7
Configuration: /home/tom/github/bcmath_compat/phpunit.xml.dist

...............................................................  63 / 152 ( 41%)
............................................................... 126 / 152 ( 82%)
..................SSSSS..S                                      152 / 152 (100%)

Time: 00:00.155, Memory: 26.86 MB

There were 6 skipped tests:

1) BCMathTest::test_argumentsScaleCallstatic with data set #1 (4, 2)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:373 : bcscale() expects at most 1 parameters, 2 given

2) BCMathTest::test_argumentsScaleCallstatic with data set #2 (4, 2, 3)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:373 : bcscale() expects at most 1 parameters, 3 given

3) BCMathTest::test_argumentsScaleCallstatic with data set #3 (4, 2, 3, 5)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:373 : bcscale() expects at most 1 parameters, 4 given

4) BCMathTest::test_argumentsPowModCallstatic with data set #0 ('9')
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:369 : bcpowmod() expects at least 3 parameters, 1 given

5) BCMathTest::test_argumentsPowModCallstatic with data set #1 ('9', '17')
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:369 : bcpowmod() expects at least 3 parameters, 2 given

6) BCMathTest::test_argumentsPowModCallstatic with data set #4 ('9', '17', '-111', 5, 8)
ArgumentCountError in /home/tom/github/bcmath_compat/vendor/phpseclib/bcmath_compat/src/BCMath.php:373 : bcpowmod() expects at most 4 parameters, 5 given

OK, but some tests were skipped!
Tests: 152, Assertions: 155, Skipped: 6.
```
Best regards, tkuschel
